### PR TITLE
feat: Docker support and test case environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ yet fully ready for production deployments.
 
 ## Usage
 
+### Running Locally
+
 Autohost takes a single JSON configuration file as argument and starts the
 operation:
 
@@ -58,9 +60,43 @@ A minimal configuration file looks like:
 
 To see all options take a look at schema in [`src/config.ts`](./src/config.ts).
 
-Autohost expects existence of `engines` folder that contains folder with
-different engine versions, for example:
+### Running with Docker
 
+For production deployments, we recommend using Docker. See the [Docker Build Documentation](./docker-build/README.md) for detailed information about building and running the container.
+
+Quick start with Docker:
+```bash
+# Build the image
+./docker-build/build.sh
+
+# Run the container
+./docker-build/run.sh -c config.json
+```
+
+### Testing
+
+For testing and development, we provide a test case environment that includes a mock Tachyon server. See the [Test Case Documentation](./testcase/README.md) for detailed information about running tests and example usage.
+
+Quick test start:
+```bash
+# Run the test case
+./testcase/testcase_run.sh -debug
+```
+
+## Directory Structure
+
+Autohost expects the following directory structure:
+
+```
+.
+├── config.json
+├── engines/
+│   └── [engine binaries]
+└── instances/
+    └── [battle instances]
+```
+
+For example:
 ```console
 $ tree engines -L 1
 engines
@@ -95,7 +131,7 @@ To start the service run
 npm run start-tachyon-fake | npx pino-pretty
 ```
 
-The service will listed for autohost on port 8084 and [`config.dev.json`](./config.dev.json)
+The service will listen for autohost on port 8084 and [`config.dev.json`](./config.dev.json)
 contains the config that will make autohost connect to it:
 
 ```
@@ -103,80 +139,7 @@ npm run start config.dev.json | npx pino-pretty
 ```
 
 The fake prints all tachyon messages it receives and sends JSON messages it
-gets via HTTP to the connected autohost. See below example session to see how
-`autohost/subscribeUpdates` and `autohost/start` are send to first connected
-autohost.
-
-#### Example session
-
-1. Set up BAR checkout as described in the main game repository
-   https://github.com/beyond-all-reason/Beyond-All-Reason.
-2. Make sure you have "Quicksilver Remake 1.24" map installed.
-3. Fetch engine
-
-    ```shell
-    curl -L https://github.com/beyond-all-reason/spring/releases/download/spring_bar_%7BBAR105%7D105.1.1-2590-gb9462a0/spring_bar_.BAR105.105.1.1-2590-gb9462a0_linux-64-minimal-portable.7z -o engine.7z
-    7z x engine.7z -o'engines/105.1.1-2590-gb9462a0 BAR105'
-    ```
-
-4. Start tachyon fake and autohost as described above.
-5. Subscribe to all updates from autohost.
-
-    ```shell
-    printf '{"since":%d}' $(date '+%s%6N') | curl --json @- http://127.0.0.1:8084/request/0/subscribeUpdates
-    ```
-
-6. Create a simple start script request in `start.json`:
-
-    <!-- prettier-ignore -->
-    ```json
-    {
-      "battleId": null,
-      "engineVersion": "105.1.1-2590-gb9462a0 BAR105",
-      "gameName": "Beyond All Reason $VERSION",
-      "mapName": "Quicksilver Remake 1.24",
-      "startPosType": "ingame",
-      "allyTeams": [{
-        "startBox": { "top": 0, "bottom": 0.3, "left": 0, "right": 1 },
-        "teams": [{
-          "faction": "Cortex",
-          "bots": [{
-            "aiShortName": "BARb",
-            "aiVersion": "stable",
-            "hostUserId": "11111"
-          }]
-        }]
-      }, {
-        "startBox": { "top": 0.7, "bottom": 1, "left": 0, "right": 1 },
-        "teams": [{
-          "faction": "Armada",
-          "players": [{
-            "userId": "11111",
-            "name": "Player",
-            "password": "password1"
-          }]
-        }]
-      }]
-    }
-    ```
-
-7. Start the engine dedicated in autohost:
-
-    ```shell
-    jq ".battleId = \"$(uuidgen -r)\"" start.json | curl --json @- http://127.0.0.1:8084/request/0/start
-    ```
-
-8. Join the game yourself, using the port that will be printed on the tachyon
-   server fake output and user name and password from `start.json`:
-
-    ```shell
-    ./engines/105.1.1-2590-gb9462a0\ BAR105/spring --isolation --write-dir "{absolute path to your data folder}""  spring://Player:password1@127.0.0.1:20001
-    ```
-
-> [!NOTE]
-> Until [a fix](https://github.com/beyond-all-reason/spring/pull/1876) gets
-> released in some of the future engine version, you have only 30s between
-> autohost starts the game and you connect to it.
+gets via HTTP to the connected autohost. See the [Test Case Documentation](./testcase/README.md) for an example session showing how to use the fake server.
 
 [Recoil]: https://github.com/beyond-all-reason/spring
 [Tachyon]: https://github.com/beyond-all-reason/tachyon

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,0 +1,52 @@
+# Build stage
+FROM node:22-slim AS builder
+
+# Set working directory
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Runtime stage
+FROM node:22-slim
+
+# Install tini
+RUN apt-get update && apt-get install -y tini curl && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN groupadd -r recoil && useradd -r -g recoil recoil
+
+# Set working directory
+WORKDIR /app
+
+# Copy built application from builder
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package*.json ./
+COPY --from=builder /app/node_modules ./node_modules
+
+# Create necessary directories and set permissions
+RUN mkdir -p /app/engines /app/instances && \
+    chown -R recoil:recoil /app/engines /app/instances && \
+    chmod -R 755 /app/engines /app/instances
+
+# Copy and set permissions for entrypoint script
+COPY docker-build/docker-entrypoint.sh /app/
+RUN chmod +x /app/docker-entrypoint.sh && \
+    chown recoil:recoil /app/docker-entrypoint.sh
+
+# Switch to non-root user
+USER recoil
+
+# Set environment variables
+ENV NODE_ENV=production
+
+ENTRYPOINT ["/usr/bin/tini", "-s", "--", "/app/docker-entrypoint.sh"] 

--- a/docker-build/README.md
+++ b/docker-build/README.md
@@ -1,0 +1,150 @@
+# Docker Build Configuration
+
+This directory contains Docker-related files for building and running the Recoil Autohost service. For general information about the Recoil Autohost service, see the [main README](../README.md). For information about testing with Docker, see the [Test Case Documentation](../testcase/README.md).
+
+## Files
+
+- `Dockerfile`: Multi-stage build configuration using Node.js 22 Debian-slim
+- `build.sh`: Script to build the Docker image
+- `run.sh`: Script to run the container with configurable options
+- `docker-compose.yml`: Docker Compose configuration for easy deployment
+- `docker-entrypoint.sh`: Entrypoint script for container initialization and permissions
+
+## Prerequisites
+
+- Docker installed on your system
+- Docker Compose (optional, for using docker-compose.yml)
+- A valid `config.json` file in the project root
+- An `engines` directory containing the game engine binaries
+- Host system with glibc support (required for Spring engine binaries)
+
+## Building the Image
+
+You can build the Docker image using either method:
+
+### Using build.sh
+The `build.sh` script provides options for custom tagging and publishing to a registry:
+
+```bash
+./docker-build/build.sh [OPTIONS]
+```
+
+Options:
+- `-t tag`: Specify a custom tag for the image (default: "latest")
+- `-p registry`: Specify a registry to publish to (e.g., "docker.io/username")
+- `-h`: Show help/usage information
+
+Examples:
+```bash
+# Basic build with default tag (latest)
+./docker-build/build.sh
+
+# Build with custom tag
+./docker-build/build.sh -t v1.0.0
+
+# Build and publish to registry
+./docker-build/build.sh -t v1.0.0 -p docker.io/username
+
+# Show help
+./docker-build/build.sh -h
+```
+
+### Using Docker directly
+```bash
+docker build -t recoil-autohost:latest -f docker-build/Dockerfile .
+```
+
+## Running the Container
+
+### Using run.sh
+The `run.sh` script provides a convenient way to run the container with configurable options:
+
+```bash
+./docker-build/run.sh [OPTIONS]
+```
+
+Options:
+- `-n, --name NAME`: Container name (default: recoil-autohost)
+- `-c, --config FILE`: Config file path (default: config.json)
+- `-e, --engines DIR`: Engines directory path (default: engines)
+- `-i, --instances DIR`: Instances directory path (default: instances)
+- `-p, --port PORT`: Port to expose (default: 8084)
+- `-h, --help`: Show help message
+
+Example:
+```bash
+./docker-build/run.sh -p 8085 -c custom-config.json
+```
+
+### Using Docker Compose
+```bash
+docker-compose -f docker-build/docker-compose.yml up -d
+```
+
+## Directory Structure
+
+The container expects the following directory structure in your project root:
+
+```
+.
+├── config.json
+├── engines/
+│   └── [engine binaries]
+└── instances/
+    └── [battle instances]
+```
+
+## Configuration
+
+The service uses a `config.json` file for all configuration settings. The file should be mounted into the container at `/app/config.json`. See the [main README](../README.md) for configuration options and examples.
+
+## Health Check
+
+The container includes a health check that monitors the service on port 8084. The health check:
+- Runs every 30 seconds
+- Has a timeout of 10 seconds
+- Retries 3 times before marking unhealthy
+- Has a 10-second grace period on startup
+
+## Volumes
+
+The following directories are mounted as volumes:
+- `config.json`: Configuration file
+- `engines/`: Game engine binaries
+- `instances/`: Battle instance data
+
+## Security
+
+- The container runs as a non-root user (recoil)
+- Uses tini as an init system for proper process management
+- Based on Debian-slim for better glibc compatibility
+- Permissions are managed by the entrypoint script
+
+## Troubleshooting
+
+1. If the container fails to start, check:
+   - The config.json file exists and is valid
+   - The engines directory contains the required binaries
+   - The port 8084 is not in use
+   - The entrypoint script has execute permissions
+   - The host system has glibc installed
+   - The mounted directories have correct permissions
+
+2. To view container logs:
+   ```bash
+   docker logs recoil-autohost
+   ```
+
+3. To check container permissions:
+   ```bash
+   docker exec recoil-autohost ls -la /app/engines /app/instances
+   ```
+
+4. To stop the container:
+   ```bash
+   docker stop recoil-autohost
+   ```
+
+## Testing
+
+For testing the Docker container, see the [Test Case Documentation](../testcase/README.md) which includes a complete example of running the service in a test environment. 

--- a/docker-build/README.md
+++ b/docker-build/README.md
@@ -13,7 +13,6 @@ This directory contains Docker-related files for building and running the Recoil
 ## Prerequisites
 
 - Docker installed on your system
-- Docker Compose (optional, for using docker-compose.yml)
 - A valid `config.json` file in the project root
 - An `engines` directory containing the game engine binaries
 - Host system with glibc support (required for Spring engine binaries)

--- a/docker-build/build.sh
+++ b/docker-build/build.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Exit on error
+set -e
+
+# Default values
+IMAGE_NAME="recoil-autohost"
+TAG="latest"
+REGISTRY=""
+PUBLISH=false
+
+# Print usage
+usage() {
+    echo "Usage: $0 [-t tag] [-p registry]"
+    echo "  -t tag      : Tag to use for the image (default: latest)"
+    echo "  -p registry : Registry to publish to (e.g., docker.io/username)"
+    echo "               If specified, the image will be published to the registry"
+    exit 1
+}
+
+# Parse command line arguments
+while getopts "t:p:h" opt; do
+    case $opt in
+        t)
+            TAG="$OPTARG"
+            ;;
+        p)
+            REGISTRY="$OPTARG"
+            PUBLISH=true
+            ;;
+        h)
+            usage
+            ;;
+        \?)
+            echo "Invalid option: -$OPTARG" >&2
+            usage
+            ;;
+    esac
+done
+
+# Construct image names
+LOCAL_IMAGE="${IMAGE_NAME}:${TAG}"
+if [ -n "$REGISTRY" ]; then
+    REMOTE_IMAGE="${REGISTRY}/${IMAGE_NAME}:${TAG}"
+fi
+
+# Build the image
+echo "Building image ${LOCAL_IMAGE}..."
+docker build -t "${LOCAL_IMAGE}" -f docker-build/Dockerfile .
+echo "Successfully built ${LOCAL_IMAGE}"
+
+# If registry is specified, tag and push the image
+if [ "$PUBLISH" = true ]; then
+    echo "Tagging image for registry: ${REMOTE_IMAGE}"
+    docker tag "${LOCAL_IMAGE}" "${REMOTE_IMAGE}"
+    
+    echo "Publishing image to registry..."
+    docker push "${REMOTE_IMAGE}"
+    echo "Successfully published ${REMOTE_IMAGE}"
+fi 

--- a/docker-build/docker-entrypoint.sh
+++ b/docker-build/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Start the application
+exec /usr/bin/tini -- node dist/main.js 

--- a/docker-build/run.sh
+++ b/docker-build/run.sh
@@ -1,0 +1,90 @@
+#!/bin/sh
+
+# Exit on error
+set -e
+
+# Default values
+CONTAINER_NAME="recoil-autohost"
+CONFIG_FILE="config.json"
+ENGINES_DIR="engines"
+INSTANCES_DIR="instances"
+PORT=8084
+
+# Help function
+show_help() {
+    echo "Usage: $0 [OPTIONS]"
+    echo "Run the recoil-autohost container"
+    echo ""
+    echo "Options:"
+    echo "  -n, --name NAME     Container name (default: $CONTAINER_NAME)"
+    echo "  -c, --config FILE   Config file path (default: $CONFIG_FILE)"
+    echo "  -e, --engines DIR   Engines directory path (default: $ENGINES_DIR)"
+    echo "  -i, --instances DIR Instances directory path (default: $INSTANCES_DIR)"
+    echo "  -p, --port PORT     Port to expose (default: $PORT)"
+    echo "  -h, --help          Show this help message"
+}
+
+# Parse command line arguments
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        -n|--name)
+            CONTAINER_NAME="$2"
+            shift 2
+            ;;
+        -c|--config)
+            CONFIG_FILE="$2"
+            shift 2
+            ;;
+        -e|--engines)
+            ENGINES_DIR="$2"
+            shift 2
+            ;;
+        -i|--instances)
+            INSTANCES_DIR="$2"
+            shift 2
+            ;;
+        -p|--port)
+            PORT="$2"
+            shift 2
+            ;;
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+# Check if config file exists
+if [ ! -f "$CONFIG_FILE" ]; then
+    echo "Error: Config file '$CONFIG_FILE' not found"
+    exit 1
+fi
+
+# Check if engines directory exists
+if [ ! -d "$ENGINES_DIR" ]; then
+    echo "Error: Engines directory '$ENGINES_DIR' not found"
+    exit 1
+fi
+
+# Create instances directory if it doesn't exist
+mkdir -p "$INSTANCES_DIR"
+
+# Run the container
+docker run -d \
+    --name "$CONTAINER_NAME" \
+    -p "$PORT:8084" \
+    -v "$(pwd)/$CONFIG_FILE:/app/config.json" \
+    -v "$(pwd)/$ENGINES_DIR:/app/engines" \
+    -v "$(pwd)/$INSTANCES_DIR:/app/instances" \
+    recoil-autohost:latest
+
+echo "Container '$CONTAINER_NAME' started successfully"
+echo "Port: $PORT"
+echo "Config file: $CONFIG_FILE"
+echo "Engines directory: $ENGINES_DIR"
+echo "Instances directory: $INSTANCES_DIR" 

--- a/src/tachyonServer.fake.ts
+++ b/src/tachyonServer.fake.ts
@@ -101,7 +101,7 @@ export class TachyonServer<F extends Fastify.FastifyInstance> extends TypedEmitt
 	}
 
 	start() {
-		return this.fastifyServer.listen({ port: this.askedPort });
+		return this.fastifyServer.listen({ port: this.askedPort, host: '0.0.0.0' });
 	}
 
 	close() {
@@ -173,14 +173,19 @@ export async function createTachyonServer(options?: TachyonServerOpts) {
 		reply.send(error);
 	});
 
-	server.get('/.well-known/oauth-authorization-server', async (_req, resp) => {
+	server.get('/.well-known/oauth-authorization-server', async (req, resp) => {
 		const port = server.addresses()[0].port;
+		const hostname = req.hostname;
 		resp.header('cache-control', 'max-age=3600, public');
 		return {
-			issuer: `http://localhost:${port}`,
-			token_endpoint: `http://localhost:${port}/token`,
+			issuer: `http://${hostname}:${port}`,
+			token_endpoint: `http://${hostname}:${port}/token`,
 			response_types_supported: ['token'],
 		};
+	});
+
+	server.get('/health', async (_req, resp) => {
+		return { status: 'ok' };
 	});
 
 	const validAccessTokens = new Set<string>();

--- a/testcase/.gitignore
+++ b/testcase/.gitignore
@@ -1,0 +1,11 @@
+# Engine files
+engines/
+
+# Instance files
+instances/
+
+# Temporary log files
+test_logs/
+
+# Downloaded engine archive
+engine.7z 

--- a/testcase/README.md
+++ b/testcase/README.md
@@ -1,0 +1,218 @@
+# Recoil Autohost Test Case
+
+This directory contains a test suite for validating the basic connectivity and functionality of the Recoil Autohost service.
+
+## Quick Start
+
+```bash
+# Install prerequisites (Ubuntu/Debian)
+sudo apt-get update && sudo apt-get install -y \
+    docker.io \
+    docker-compose \
+    curl \
+    jq \
+    p7zip-full \
+    uuid-runtime
+
+# Run the test (from project root)
+sudo ./testcase/testcase_run.sh -debug
+```
+
+## Test Environment
+
+The test environment consists of two Docker containers:
+
+1. `tachyon-fake`: A mock Tachyon lobby server
+   - Provides authentication and basic lobby functionality
+   - Runs on port 8084
+   - Includes health check endpoint
+
+2. `recoil-autohost`: The service being tested
+   - Connects to the mock Tachyon server
+   - Validates connection and API functionality
+
+## Test Script Usage
+
+```bash
+sudo ./testcase_run.sh [-debug] [-timeout seconds]
+```
+
+### Options
+
+- `-debug`: Enable detailed logging output (recommended for troubleshooting)
+- `-timeout`: Set custom test timeout in seconds (default: 60)
+
+### Examples
+
+```bash
+# Basic test
+sudo ./testcase_run.sh
+
+# Test with debug output
+sudo ./testcase_run.sh -debug
+
+# Test with longer timeout
+sudo ./testcase_run.sh -timeout 120
+
+# Test with both debug and custom timeout
+sudo ./testcase_run.sh -debug -timeout 120
+```
+
+## What the Test Validates
+
+1. **Service Startup**
+   - Docker containers start successfully
+   - Services are healthy and responsive
+
+2. **Connection**
+   - Recoil-autohost connects to Tachyon server
+   - Connection is stable and authenticated
+
+3. **API Functionality**
+   - OAuth2 token endpoint works
+   - Updates subscription endpoint works
+
+## Example Session
+
+The test case demonstrates a complete example of starting a game with the autohost service:
+
+1. Set up BAR checkout as described in the main game repository
+   https://github.com/beyond-all-reason/Beyond-All-Reason.
+
+2. Make sure you have "Quicksilver Remake 1.24" map installed.
+
+3. Fetch engine
+   ```shell
+   curl -L https://github.com/beyond-all-reason/spring/releases/download/spring_bar_%7BBAR105%7D105.1.1-2590-gb9462a0/spring_bar_.BAR105.105.1.1-2590-gb9462a0_linux-64-minimal-portable.7z -o engine.7z
+   7z x engine.7z -o'engines/105.1.1-2590-gb9462a0 BAR105'
+   ```
+
+4. Start tachyon fake and autohost as described above.
+
+5. Subscribe to all updates from autohost.
+   ```shell
+   printf '{"since":%d}' $(date '+%s%6N') | curl --json @- http://127.0.0.1:8084/request/0/subscribeUpdates
+   ```
+
+6. Create a simple start script request in `start.json`:
+   ```json
+   {
+     "battleId": null,
+     "engineVersion": "105.1.1-2590-gb9462a0 BAR105",
+     "gameName": "Beyond All Reason $VERSION",
+     "mapName": "Quicksilver Remake 1.24",
+     "startPosType": "ingame",
+     "allyTeams": [{
+       "startBox": { "top": 0, "bottom": 0.3, "left": 0, "right": 1 },
+       "teams": [{
+         "faction": "Cortex",
+         "bots": [{
+           "aiShortName": "BARb",
+           "aiVersion": "stable",
+           "hostUserId": "11111"
+         }]
+       }]
+     }, {
+       "startBox": { "top": 0.7, "bottom": 1, "left": 0, "right": 1 },
+       "teams": [{
+         "faction": "Armada",
+         "players": [{
+           "userId": "11111",
+           "name": "Player",
+           "password": "password1"
+         }]
+       }]
+     }]
+   }
+   ```
+
+7. Start the engine dedicated in autohost:
+   ```shell
+   jq ".battleId = \"$(uuidgen -r)\"" start.json | curl --json @- http://127.0.0.1:8084/request/0/start
+   ```
+
+8. Join the game yourself, using the port that will be printed on the tachyon
+   server fake output and user name and password from `start.json`:
+   ```shell
+   ./engines/105.1.1-2590-gb9462a0\ BAR105/spring --isolation --write-dir "{absolute path to your data folder}" spring://Player:password1@127.0.0.1:20001
+   ```
+
+> [!NOTE]
+> Until [a fix](https://github.com/beyond-all-reason/spring/pull/1876) gets
+> released in some of the future engine version, you have only 30s between
+> autohost starts the game and you connect to it.
+
+## Test Output
+
+The test provides clear visual feedback:
+- ✓ Green checkmarks for successful steps
+- ✗ Red X's for failures
+- ➜ Blue arrows for progress updates
+- Yellow headers for test sections
+
+Example successful output:
+```
+=== Test Environment Setup ===
+➜ Starting Docker services...
+✓ Containers are ready
+✓ Docker services started
+
+=== Connection Setup ===
+✓ Connection established successfully
+
+=== API Test ===
+✓ OAuth2 token endpoint working
+✓ Updates subscription working
+
+=== Test Complete ===
+✓ All core functionality tests passed
+
+=== Cleanup ===
+✓ Test completed successfully
+```
+
+## Automatic Cleanup
+
+The test script automatically cleans up all resources, regardless of test outcome:
+- Stops and removes Docker containers
+- Cleans up the `engines` directory
+- Cleans up the `instances` directory
+- Removes Docker networks
+
+Cleanup triggers on:
+- Normal test completion
+- Test failures
+- Timeouts
+- User interruption (Ctrl+C)
+
+## Troubleshooting
+
+If the test fails:
+
+1. **Run with debug output**
+   ```bash
+   sudo ./testcase_run.sh -debug
+   ```
+
+2. **Check Docker logs**
+   ```bash
+   docker compose logs recoil-autohost
+   docker compose logs tachyon-fake
+   ```
+
+3. **Verify prerequisites**
+   - Docker and Docker Compose are installed and running
+   - Required ports (8084) are available
+   - User has sudo privileges
+
+4. **Common Issues**
+   - OAuth2 credentials mismatch
+   - Network connectivity problems
+   - Port conflicts
+   - Insufficient permissions
+
+## Configuration Files
+
+- `docker-compose.yml`: Defines the test environment
+- `config.dev.json`: Configures the Recoil Autohost service
+- `tachyonfake/`: Contains the mock Tachyon server implementation 

--- a/testcase/README.md
+++ b/testcase/README.md
@@ -8,7 +8,6 @@ This directory contains a test suite for validating the basic connectivity and f
 # Install prerequisites (Ubuntu/Debian)
 sudo apt-get update && sudo apt-get install -y \
     docker.io \
-    docker-compose \
     curl \
     jq \
     p7zip-full \

--- a/testcase/docker-compose.yml
+++ b/testcase/docker-compose.yml
@@ -1,0 +1,45 @@
+services:
+  tachyon-fake:
+    build:
+      context: ..
+      dockerfile: testcase/tachyonfake/Dockerfile
+    init: true
+    environment:
+      - TINI_SUBREAPER=true
+    ports:
+      - "8084:8084"
+    networks:
+      - autohost-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8084/health"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+
+  recoil-autohost:
+    build:
+      context: ..
+      dockerfile: docker-build/Dockerfile
+    init: true
+    volumes:
+      - ./engines:/app/engines:ro
+      - ./instances:/app/instances:rw
+      - ./testconfig.json:/app/config.json:ro
+    user: "1000:1000"  # Run as non-root user
+    environment:
+      - TINI_SUBREAPER=true
+    entrypoint: ["/usr/bin/tini", "-s", "--"]
+    command: ["node", "dist/main.js", "/app/config.json"]
+    ports:
+      - "20001-20010:20001-20010"
+      - "22001-22010:22001-22010"
+    depends_on:
+      tachyon-fake:
+        condition: service_healthy
+    networks:
+      - autohost-network
+
+networks:
+  autohost-network:
+    driver: bridge 

--- a/testcase/start.json
+++ b/testcase/start.json
@@ -1,0 +1,28 @@
+{
+  "battleId": null,
+  "engineVersion": "105.1.1-2590-gb9462a0 BAR105",
+  "gameName": "Beyond All Reason $VERSION",
+  "mapName": "Quicksilver Remake 1.24",
+  "startPosType": "ingame",
+  "allyTeams": [{
+    "startBox": { "top": 0, "bottom": 0.3, "left": 0, "right": 1 },
+    "teams": [{
+      "faction": "Cortex",
+      "bots": [{
+        "aiShortName": "BARb",
+        "aiVersion": "stable",
+        "hostUserId": "11111"
+      }]
+    }]
+  }, {
+    "startBox": { "top": 0.7, "bottom": 1, "left": 0, "right": 1 },
+    "teams": [{
+      "faction": "Armada",
+      "players": [{
+        "userId": "11111",
+        "name": "Player",
+        "password": "password1"
+      }]
+    }]
+  }]
+}

--- a/testcase/tachyonfake/Dockerfile
+++ b/testcase/tachyonfake/Dockerfile
@@ -1,0 +1,32 @@
+FROM node:22-slim
+
+# Install curl for health check and tini for process management
+RUN apt-get update && apt-get install -y curl tini && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the tachyon fake server implementation
+COPY src/tachyonServer.fake.ts ./src/
+COPY src/tachyonTypes.ts ./src/
+COPY src/tachyonTypes.test.ts ./src/
+COPY src/oauth2Client.ts ./src/
+COPY src/oauth2Client.test.ts ./src/
+COPY tsconfig.json ./
+
+# Build TypeScript files
+RUN npm run build
+
+# Expose the port that tachyon fake server uses
+EXPOSE 8084
+
+# Use Tini as entrypoint with subreaper mode
+ENTRYPOINT ["/usr/bin/tini", "-s", "--"]
+
+# Start the tachyon fake server
+CMD ["node", "dist/tachyonServer.fake.js"] 

--- a/testcase/tachyonfake/package.json
+++ b/testcase/tachyonfake/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "tachyon-fake",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "start-tachyon-fake": "node --loader ts-node/esm src/tachyonServer.fake.ts"
+  },
+  "dependencies": {
+    "fastify": "^4.26.1",
+    "@fastify/websocket": "^8.3.0",
+    "@fastify/formbody": "^7.4.0",
+    "@fastify/basic-auth": "^3.0.1",
+    "ws": "^8.16.0",
+    "pino": "^8.17.2",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
+  }
+} 

--- a/testcase/testcase_run.sh
+++ b/testcase/testcase_run.sh
@@ -1,0 +1,281 @@
+#!/bin/bash
+set -e
+
+# Check if running as root/sudo
+if [ "$EUID" -ne 0 ]; then
+    echo "Please run this script as root (sudo ./testcase_run.sh)"
+    exit 1
+fi
+
+# Colors for output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Global variables
+DOCKER_RUNNING=false
+DEBUG=false
+TEST_TIMEOUT=60  # Timeout in seconds
+TEST_START_TIME=0
+TEST_STATUS="NOT_STARTED"
+CLEANUP_DONE=false
+LOG_PID=""
+
+# Function to print section headers
+print_header() {
+    echo -e "\n${YELLOW}=== $1 ===${NC}"
+}
+
+# Function to print status updates
+print_status() {
+    echo -e "${BLUE}➜ $1${NC}"
+}
+
+# Function to print success messages
+print_success() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+# Function to print error messages
+print_error() {
+    echo -e "${RED}✗ $1${NC}"
+}
+
+# Function to clean directories
+clean_directories() {
+    local dir="$1"
+    print_status "Cleaning directory: $dir"
+    if [ -d "$dir" ]; then
+        # First try to remove contents only
+        rm -rf "${dir:?}"/* 2>/dev/null || {
+            # If that fails, try with sudo
+            sudo rm -rf "${dir:?}"/* 2>/dev/null || {
+                print_error "Failed to clean $dir"
+                return 1
+            }
+        }
+        print_success "Cleaned $dir"
+    fi
+}
+
+# Function to start log streaming in background
+start_log_streaming() {
+    if [ "$DEBUG" = true ]; then
+        print_status "Starting log streaming..."
+        docker compose logs -f &
+        LOG_PID=$!
+    fi
+}
+
+# Function to stop log streaming
+stop_log_streaming() {
+    if [ -n "$LOG_PID" ]; then
+        kill $LOG_PID 2>/dev/null || true
+        LOG_PID=""
+    fi
+}
+
+# Cleanup function
+cleanup() {
+    # Prevent duplicate cleanup
+    if [ "$CLEANUP_DONE" = true ]; then
+        return
+    fi
+    CLEANUP_DONE=true
+
+    # Stop log streaming if active
+    stop_log_streaming
+
+    print_header "Cleanup"
+    
+    # Print test status
+    case $TEST_STATUS in
+        "SUCCESS")
+            print_success "Test completed successfully"
+            ;;
+        "TIMEOUT")
+            print_error "Test timed out after $TEST_TIMEOUT seconds"
+            ;;
+        "FAILED")
+            print_error "Test failed"
+            ;;
+        *)
+            print_status "Test was interrupted"
+            ;;
+    esac
+    
+    # Stop Docker services if they're running
+    if [ "$DOCKER_RUNNING" = true ]; then
+        print_status "Stopping Docker services..."
+        cd "${SCRIPT_DIR}" && docker compose down || true
+    fi
+
+    # Clean up directories
+    print_status "Cleaning up test directories..."
+    clean_directories "${SCRIPT_DIR}/engines"
+    clean_directories "${SCRIPT_DIR}/instances"
+    
+    # Exit with appropriate status code
+    case $TEST_STATUS in
+        "SUCCESS")
+            exit 0
+            ;;
+        *)
+            exit 1
+            ;;
+    esac
+}
+
+# Function to check if test has timed out
+check_timeout() {
+    if [ $TEST_START_TIME -ne 0 ]; then
+        current_time=$(date +%s)
+        elapsed=$((current_time - TEST_START_TIME))
+        if [ $elapsed -gt $TEST_TIMEOUT ]; then
+            TEST_STATUS="TIMEOUT"
+            print_error "Test timed out after $TEST_TIMEOUT seconds"
+            cleanup
+        fi
+    fi
+}
+
+# Set up cleanup traps for various exit scenarios
+trap cleanup EXIT
+trap 'TEST_STATUS="INTERRUPTED"; cleanup' INT TERM
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -debug)
+            DEBUG=true
+            shift
+            ;;
+        -timeout)
+            shift
+            if [[ $1 =~ ^[0-9]+$ ]]; then
+                TEST_TIMEOUT=$1
+                shift
+            else
+                print_error "Invalid timeout value: $1"
+                echo "Usage: $0 [-debug] [-timeout seconds]"
+                exit 1
+            fi
+            ;;
+        *)
+            print_error "Unknown option: $1"
+            echo "Usage: $0 [-debug] [-timeout seconds]"
+            exit 1
+            ;;
+    esac
+done
+
+# Script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+print_header "Test Environment Setup"
+TEST_START_TIME=$(date +%s)
+
+print_header "Starting Services"
+
+# Start Docker services
+cd "${SCRIPT_DIR}"
+print_status "Starting Docker services..."
+docker compose up -d || {
+    TEST_STATUS="FAILED"
+    print_error "Failed to start Docker services"
+    exit 1
+}
+DOCKER_RUNNING=true
+
+# Start log streaming if debug mode is enabled
+start_log_streaming
+
+# Wait for containers to be ready
+print_status "Waiting for containers to be ready..."
+max_attempts=30
+attempt=1
+while [ $attempt -le $max_attempts ]; do
+    if docker compose ps | grep -q "healthy"; then
+        print_success "Containers are ready"
+        break
+    fi
+    print_status "Waiting for containers (attempt $attempt/$max_attempts)..."
+    sleep 2
+    ((attempt++))
+done
+
+if [ $attempt -gt $max_attempts ]; then
+    TEST_STATUS="FAILED"
+    print_error "Containers failed to become ready"
+    if [ "$DEBUG" = false ]; then
+        docker compose logs
+    fi
+    exit 1
+fi
+
+print_success "Docker services started"
+
+# Wait for services to start and establish connection
+print_header "Connection Setup"
+
+wait_for_connection() {
+    local max_attempts=30
+    local attempt=1
+    
+    while [ $attempt -le $max_attempts ]; do
+        check_timeout
+        
+        if docker compose logs recoil-autohost | grep -q "connected to tachyon server"; then
+            print_success "Connection established successfully"
+            return 0
+        fi
+        print_status "Waiting for connection (attempt $attempt/$max_attempts)..."
+        sleep 2
+        ((attempt++))
+    done
+    
+    TEST_STATUS="FAILED"
+    print_error "Connection timeout"
+    print_error "Last few lines of logs:"
+    docker compose logs --tail 50
+    exit 1
+}
+
+wait_for_connection
+
+print_header "API Test"
+
+# Test OAuth2 token endpoint
+print_status "Testing OAuth2 token endpoint..."
+token_response=$(curl -s -u "autohost1:pass1" -d "grant_type=client_credentials&scope=tachyon.lobby" http://127.0.0.1:8084/token)
+access_token=$(echo "$token_response" | jq -r '.access_token')
+
+if [ -z "$access_token" ] || [ "$access_token" = "null" ]; then
+    TEST_STATUS="FAILED"
+    print_error "Failed to get access token"
+    print_error "Token response: $token_response"
+    exit 1
+fi
+
+print_success "OAuth2 token endpoint working"
+
+# Test updates subscription
+print_status "Testing updates subscription..."
+TIMESTAMP=$(date '+%s%6N')
+subscribe_response=$(curl -s --json "{\"since\":$TIMESTAMP}" http://localhost:8084/request/0/subscribeUpdates)
+if [ $? -ne 0 ]; then
+    TEST_STATUS="FAILED"
+    print_error "Failed to subscribe to updates"
+    print_error "Response: $subscribe_response"
+    exit 1
+fi
+
+print_success "Updates subscription working"
+
+print_header "Test Complete"
+print_success "All core functionality tests passed"
+TEST_STATUS="SUCCESS"
+
+cleanup 

--- a/testcase/testconfig.json
+++ b/testcase/testconfig.json
@@ -1,11 +1,12 @@
 {
-  "tachyonServer": "localhost",
+  "tachyonServer": "tachyon-fake",
   "tachyonServerPort": 8084,
+  "useSecureConnection": false,
   "authClientId": "autohost1",
   "authClientSecret": "pass1",
   "hostingIP": "127.0.0.1",
   "engineSettings": {
-    "InitialNetworkTimeout": 1000,
-    "LogFlushLevel": 0
+    "InitialNetworkTimeout": "1000",
+    "LogFlushLevel": "0"
   }
 }


### PR DESCRIPTION
Added Docker support and a test environment to streamline development.

changes:
- Added `docker-build` folder with Dockerfile and usage instructions for recoil-autohost
  - Added docker-build/build.sh with some flags that can build and publish to a registry with a specified tag
- Created a test scenario with containerized fake tachyon server
  - Added test script that sets up a battle using `start.json`
- Enhanced/changed  the fake server for Docker:
  - Added health check endpoint for readiness
  - Configured to listen on all interfaces (0.0.0.0)
- Added `docker-compose.yml` for test orchestration, used only in the test setup

The test case is pretty simple - just run `./testcase/testcase_run.sh` Documentation is available in the `docker-build/` and `testcase/` READMEs.

I made effort to preserve functionality for local testing without docker as well, and old documentation should be available and accurate