### PR TITLE
Issue #13: Added max battle duration limit

### DIFF
--- a/src/autohost.test.ts
+++ b/src/autohost.test.ts
@@ -279,6 +279,20 @@ suite('Autohost', async () => {
 		assert.equal(er.close.mock.callCount(), 1);
 	});
 
+	await test('timeout kill', async () => {
+		const er = new EngineRunnerFake();
+		const env = getEnv(() => er);
+		env.config.maxGameDurationSeconds = 0.1;
+		const gm = new GamesManager(env);
+		const ah = new Autohost(env, gm, new EngineVersionsManagerFake());
+		const req = createStartRequest([{ name: 'user1', userId: randomUUID() }]);
+		await ah.start(req);
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		assert.equal(er.close.mock.callCount(), 0);
+		await new Promise((resolve) => setTimeout(resolve, 150));
+		assert.equal(er.close.mock.callCount(), 1);
+	});
+
 	await test('kill battle not found', async () => {
 		const env = getEnv();
 		const gm = new GamesManager(env);

--- a/src/autohost.test.ts
+++ b/src/autohost.test.ts
@@ -279,17 +279,20 @@ suite('Autohost', async () => {
 		assert.equal(er.close.mock.callCount(), 1);
 	});
 
-	await test('timeout kill', async () => {
+	await test('timeout kill', async (t) => {
+		t.mock.timers.enable({ apis: ['setTimeout'] });
 		const er = new EngineRunnerFake();
 		const env = getEnv(() => er);
 		env.config.maxGameDurationSeconds = 0.1;
 		const gm = new GamesManager(env);
 		const ah = new Autohost(env, gm, new EngineVersionsManagerFake());
 		const req = createStartRequest([{ name: 'user1', userId: randomUUID() }]);
-		await ah.start(req);
-		await new Promise((resolve) => setTimeout(resolve, 50));
+		const startPromise = ah.start(req);
+		t.mock.timers.tick(0);
+		await startPromise;
+		t.mock.timers.tick(99);
 		assert.equal(er.close.mock.callCount(), 0);
-		await new Promise((resolve) => setTimeout(resolve, 150));
+		t.mock.timers.tick(1);
 		assert.equal(er.close.mock.callCount(), 1);
 	});
 

--- a/src/autohost.test.ts
+++ b/src/autohost.test.ts
@@ -148,6 +148,7 @@ suite('Autohost', async () => {
 				hostingIP: '127.0.0.1',
 				engineSettings: {},
 				maxUpdatesSubscriptionAgeSeconds: 10 * 60,
+				maxGameDurationSeconds: 8 * 60 * 60,
 			},
 			mocks: { runEngine: runEngineMock ?? fakeRunEngine },
 		};

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,6 +23,7 @@ export interface Config {
 	engineAutohostStartPort: number;
 	maxPortsUsed: number;
 	engineInstallTimeoutSeconds: number;
+	maxGameDurationSeconds: number;
 }
 
 const ConfigSchema: JSONSchemaType<Config> = {
@@ -108,6 +109,12 @@ const ConfigSchema: JSONSchemaType<Config> = {
 			description: 'Hard timeout for engine installation by engine manager',
 			default: 10 * 60,
 			minimum: 5,
+		},
+		maxGameDurationSeconds: {
+			type: 'number',
+			description: 'How many seconds to wait before automatically killing the game.',
+			default: 8 * 60 * 60,
+			minimum: 60 * 60,
 		},
 	},
 	required: ['tachyonServer', 'authClientId', 'authClientSecret', 'hostingIP'],

--- a/src/games.ts
+++ b/src/games.ts
@@ -172,12 +172,14 @@ export class GamesManager extends TypedEmitter<Events> implements GamesManager {
 	private createKillTimer(game: Game): NodeJS.Timeout {
 		const maxDurationSeconds = this.env.config.maxGameDurationSeconds;
 		const maxDurationMs = maxDurationSeconds * 1000;
-		return setTimeout(() => {
+		const timer = setTimeout(() => {
 			game.logger.warn(
 				`max game duration of ${maxDurationSeconds} seconds reached, forcing kill`,
 			);
 			this.killGame(game.battleId);
 		}, maxDurationMs);
+		timer.unref();
+		return timer;
 	}
 
 	get capacity(): GamesCapacity {


### PR DESCRIPTION
Tackles issue #13 

- Added `maxGameDurationSeconds` to config (default value of 8hrs)
- Creates a timeout when `start` game event emits
- If timeout is reached, kills the game
- Clears the timeout before deleting the game from the games map

There might be a safer place to the clear the timeout (slight concern about leaks if i.e. code is added that uses games.delete). Maybe the `games` map could be wrapped with a class and have `add()`, `remove()` etc. so any teardown logic is always executed.