### PR TITLE
Issue #1: Graceful shutdown

### DIFF
--- a/src/eventsBuffer.ts
+++ b/src/eventsBuffer.ts
@@ -138,6 +138,19 @@ export class EventsBuffer<T> {
 	}
 
 	/**
+	 * Wait for all events to be processed by the pusher.
+	 */
+	async drain(): Promise<void> {
+		if (!this.callback) {
+			return;
+		}
+
+		while (this.pusherRunning || this.events.length > 0) {
+			await new Promise((r) => process.nextTick(r));
+		}
+	}
+
+	/**
 	 * Length is simply number of events still in the buffer.
 	 *
 	 * Useful primarily for tests.

--- a/src/games.ts
+++ b/src/games.ts
@@ -161,7 +161,22 @@ export class GamesManager extends TypedEmitter<Events> implements GamesManager {
 		game.engineRunner.close();
 	}
 
+	killAllGames() {
+		for (const game of this.games.values()) {
+			game.engineRunner.close();
+		}
+	}
+
+	setMaxBattles(maxBattles: number) {
+		this.currCapacity.maxBattles = maxBattles;
+		this.emit('capacity', this.capacity);
+	}
+
 	get capacity(): GamesCapacity {
 		return { ...this.currCapacity };
+	}
+
+	get gameCount(): number {
+		return this.games.size;
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -37,6 +37,10 @@ async function main(argv: string[]) {
 		clientOpts.secure = config.useSecureConnection;
 	}
 
+	// Intercept the SIGINT and SIGTERM signals to allow for graceful shut down.
+	process.on('SIGINT', () => autohost.shutdown());
+	process.on('SIGTERM', () => autohost.shutdown());
+
 	// This is a simple exponential backoff reconnect loop, we
 	// just keep trying to connect to the server and if we get
 	// disconnected we wait a bit and try again.


### PR DESCRIPTION
Tackling issue-1 #1

Draft PR as I hoping for some feedback on the approach I'm taking here, before testing.

I'm using the `games` map length not the `currentBattles` value as `currentBattles` is only appended after the `start` event is recieved, so shutdown could be initiated after starting a game but before `currentBattles` is appended. I'm sure there's many more edge cases I'm not seeing here.

Thinking we could add `shuttingDown` to the Tachyon protocol status event payload if you think there's value in the Teiserver knowing? It could already infer it from `maxBattles` being `0` but might be good practise to be specific. 